### PR TITLE
[FIX]: Aligned Footer GDSC Logo for small width

### DIFF
--- a/src/Components/Footer/Footer.jsx
+++ b/src/Components/Footer/Footer.jsx
@@ -13,7 +13,7 @@ export default function Footer() {
     >
       <MDBContainer className="p-4">
         <MDBRow>
-          <MDBCol lg="4" md="12" className="mb-4 ml-6 md:ml-0 mb-md-0">
+          <MDBCol lg="4" md="12" className="mb-4 ml-7 md:ml-0 mb-md-0">
             <a
               target="_blank"
               rel="noreferrer"

--- a/src/Components/Footer/Footer.jsx
+++ b/src/Components/Footer/Footer.jsx
@@ -13,7 +13,7 @@ export default function Footer() {
     >
       <MDBContainer className="p-4">
         <MDBRow>
-          <MDBCol lg="4" md="12" className="mb-4 mb-md-0">
+          <MDBCol lg="4" md="12" className="mb-4 ml-6 md:ml-0 mb-md-0">
             <a
               target="_blank"
               rel="noreferrer"

--- a/src/Components/Header/Header.jsx
+++ b/src/Components/Header/Header.jsx
@@ -57,7 +57,7 @@ function Header() {
         </div>
       </Container>
       <Container
-        className={`absolute top-0 -z-10 flex md:hidden bg-white border-t-2 px-6 py-4 shadow-md flex justify-center transition duration-400 bg-white -mt-1 ${
+        className={`absolute top-0 -z-10 flex md:hidden bg-white border-t-2 px-6 py-4 shadow-md justify-center transition duration-400 -mt-1 ${
           shownav ? "translate-y-full" : "translate-y-0"
         }`}
       >

--- a/src/Components/Home/Discord.jsx
+++ b/src/Components/Home/Discord.jsx
@@ -13,7 +13,7 @@ function Discord() {
           style={{
             display: 'block',
             margin: 'auto',
-            maxWidth: '80%',
+            maxWidth: '85%',
             paddingBottom: '5vw',
           }}
         >


### PR DESCRIPTION
Referring to my issue #55 I've fixed the vertical alignment of the GDSC logo and also increased the width of Discord as per the mentioned cause in issue.

<hr>

<h3>Before</h3>
<img width="200px" src="https://github.com/DSC-TCET/gdsc-tcet-website/assets/111864432/ab5d35c1-fceb-4d6e-b8f0-dd9e7a002cec"/>
<h3>After</h3>
<img width="200px" src="https://github.com/DSC-TCET/gdsc-tcet-website/assets/111864432/ccb72457-5fed-4443-808a-4b68dc8e9f34">